### PR TITLE
Fix inverted exit code

### DIFF
--- a/src/nsorg/cli.clj
+++ b/src/nsorg/cli.clj
@@ -84,6 +84,11 @@
       (seq default-paths)
       ["./"]))
 
+(defn success? [options result]
+  (not (or (pos? (:errors result))
+           (and (pos? (:problems result))
+                (not (:replace options))))))
+
 (defn check
   ([args]
     (check args nil))
@@ -105,9 +110,7 @@
          (terminal/info ignored-path))
        (terminal/info))
      (let [result (organize-ns-forms! paths excluded-paths options)]
-       {:success? (or (pos? (:errors result))
-                      (and (pos? (:problems result))
-                           (not (:replace options))))
+       {:success? (success? options result)
         :summary  (summarize options result)}))))
 
 (defn -main

--- a/test/nsorg/cli_tests.clj
+++ b/test/nsorg/cli_tests.clj
@@ -20,6 +20,21 @@
 
 (tabular
   (fact
+    "Check is considered successful if there are no errors, and no problems if we're not fixing them"
+    (nsorg/success? {:replace ?replace}
+                     {:errors ?errors :problems ?problems})
+    => ?success)
+  ?replace ?errors ?problems ?success
+  false    0       0         true
+  false    2       0         false
+  false    0       3         false
+  false    2       3         false
+  true     0       3         true
+  true     2       3         false
+  true     2       3         false)
+
+(tabular
+  (fact
     "Paths are based on arguments and project source and test paths. Fallback is current working directory"
     (nsorg/get-paths ?arguments ?default-paths) => ?paths)
   ?arguments    ?default-paths         ?paths


### PR DESCRIPTION
The exit code condition was inverted: The check exited with code 0 if there were errors, and 1 if there were none. This PR fixes that.